### PR TITLE
Add Custom Exceptions to !purge

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -24,7 +24,11 @@ class ModeratorCog(commands.Cog):
 
     @commands.command()
     async def purge(self, ctx: commands.Context, count: int):
-        await ctx.channel.delete_messages(await ctx.channel.history(limit=count + 1).flatten())
+        try:
+            await ctx.channel.delete_messages(await ctx.channel.history(limit=count + 1).flatten())
+        except discord.errors.HTTPException:
+            return await ctx.channel.send("I cannot delete messages that are 2 weeks old.")
+
 
     @commands.command()
     async def say(self, ctx, *, thing):

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -17,7 +17,6 @@ allowed_role_ids = [
     378965578553098242,
     495944125124968469,
     376696109973635096,
-    393590602614308864,
     440693341735092266,
     613355321498271777,
     531633562739277844,
@@ -55,10 +54,6 @@ class RoleCog(BaseCog):
                            )
                 )
                                        )
-
-    @commands.command(name="comedy-dark")
-    async def comedy_dark(self, ctx):
-        await self.iam.callback(self, ctx, role=self.bot.get_guild(339272843327963136).get_role(393590602614308864))
 
     @commands.command(aliases=["Iam", "IAM"])
     async def iam(self, ctx: Context, *, role: typing.Union[Role, str]):


### PR DESCRIPTION
This PR updates the following file
- mod.py

This PR does the following
- Add a `try:` and `except:` to the purge command to delete messages. It will prompt a custom message than a traceback if a mod or admin tries to remove a message that is 14 days old i.e. the welcome message in #welcome.