### PR TITLE
Blacklist Update 5? + !whois change

### DIFF
--- a/cogs/blacklist.py
+++ b/cogs/blacklist.py
@@ -8,11 +8,13 @@
 # abridged
 
 ## To add new site bans, enter the site ban TXT file and type the new site to censor.
-# Save and the bot should already see the new term. MAKE SURE TO INCLUDE .[domain]
+## Save and the bot should already see the new term. MAKE SURE TO INCLUDE .[domain]
+## You can also add link contents to it and it should work properly too.
 ## Example:
 # gamejolt.com
 # itch.io
 # mega.nz
+# DDLC_MPT-1.01
 
 import discord
 from discord.ext import commands
@@ -83,7 +85,7 @@ class BlacklistCog(commands.Cog):
             for x in range(mblLength):
                 for y in range(wordLength):
                     for z in range(wblLength):
-                        wflRegexA = r"("+wordList[y]+" "+modBlacklist[x]+"$|"+wordList[y]+" "+modBlacklist[x]+" (?!"+modWhitelist[z]+"))"
+                        wflRegexA = r"(?:"+wordList[y]+" "+modBlacklist[x]+")(?! "+modWhitelist[z]+")"
                         wflMatchesA = re.finditer(wflRegexA, message.content.lower(), re.MULTILINE | re.IGNORECASE)
                         for a in enumerate(wflMatchesA, start=1):
                             # checks if user is not a mod

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -40,6 +40,16 @@ async def nat_moderator(ctx):
 def is_moderator():
     return commands.check(nat_moderator)
 
+def is_staff():
+    return commands.check(nat_staff)
+
+# all staff should pass this check unless Karl borked the perms for some reason
+async def nat_staff(ctx):
+    if ctx.author.guild_permissions.administrator or await ctx.bot.is_owner(ctx.author):
+        return True
+    else:
+        return ctx.author.guild_permissions.kick_members
+
 class OwnerCog(commands.Cog):
     bot: commands.Bot
     
@@ -224,7 +234,7 @@ class OwnerCog(commands.Cog):
         await self.bot.change_presence(activity=discord.Game(content))
 
     @commands.command(name='whois', hidden=True)
-    @is_moderator()
+    @is_staff()
     async def who(self, ctx:commands.Context, member: discord.Member = None):
         if member is None:
             member = ctx.author

--- a/modbans.txt
+++ b/modbans.txt
@@ -2,3 +2,14 @@ exit music
 one last memory
 summertime
 longer roads
+mc before rewind
+natsuki's expanded story
+not oki doki: a lost chapter
+not oki doki a lost chapter
+doki doki: true world
+doki doki true world
+coldest summer
+ddlc: the perfect story
+ddlc the perfect story
+poems and promises
+doki doki anomaly

--- a/sitebans.txt
+++ b/sitebans.txt
@@ -1,3 +1,4 @@
 ddlcmods.com
 gamejolt.com
 itch.io
+DDEM-1.1.0


### PR DESCRIPTION
Update adds more banned mods from the reddit list to the bot and improves code logic on asking for banned mods. Also adds every staff access to `!whois` by checking kick perms (goes down to Trial Mod somehow. Karl gave Trial Reddit Mod no kick perms)

Pending is adding KGK (Ko Ga Kirei?) and Emerald Heart to the list if banned. Else merge ready.